### PR TITLE
New method for adding discriminators

### DIFF
--- a/modules/tapir-anyof/src/test/scala/com/alejandrohdezma/tapir/AnyOfSuite.scala
+++ b/modules/tapir-anyof/src/test/scala/com/alejandrohdezma/tapir/AnyOfSuite.scala
@@ -36,7 +36,7 @@ class AnyOfSuite extends Http4sHttpRoutesSuite {
     endpoint.get
       .in("v1" / "users" / path[String]("id"))
       .out(stringBody)
-      .errorOut(anyOf[UserNotFound, WrongPassword, WrongUser])
+      .errorOut(anyOfThese[UserNotFound, WrongPassword, WrongUser])
       .serverLogic[IO] {
         case "1" => IO(Left(UserNotFound("1")))
         case "2" => IO(Left(WrongPassword("2")))
@@ -64,7 +64,7 @@ class AnyOfSuite extends Http4sHttpRoutesSuite {
     val myEndpoint = endpoint.get
       .in("v1" / "users" / path[String]("id"))
       .out(stringBody)
-      .errorOut(anyOf[UserNotFound])
+      .errorOut(anyOfThese[UserNotFound])
 
     val expected =
       """openapi: 3.1.0
@@ -105,9 +105,10 @@ class AnyOfSuite extends Http4sHttpRoutesSuite {
         |        name:
         |          type: string
         |        error:
-        |          type: string
+        |          type: integer
+        |          format: int32
         |          enum:
-        |          - user-not-found""".stripMargin
+        |          - 1""".stripMargin
 
     assertNoDiff(toYaml(myEndpoint), expected)
   }
@@ -116,7 +117,7 @@ class AnyOfSuite extends Http4sHttpRoutesSuite {
     val myEndpoint = endpoint.get
       .in("v1" / "users" / path[String]("id"))
       .out(stringBody)
-      .errorOut(anyOf[UserNotFound, WrongPassword, WrongUser])
+      .errorOut(anyOfThese[UserNotFound, WrongPassword, WrongUser])
 
     val expected =
       """openapi: 3.1.0
@@ -151,8 +152,8 @@ class AnyOfSuite extends Http4sHttpRoutesSuite {
         |                discriminator:
         |                  propertyName: error
         |                  mapping:
-        |                    wrong-password: '#/components/schemas/WrongPassword'
-        |                    wrong-user: '#/components/schemas/WrongUser'
+        |                    '2': '#/components/schemas/WrongPassword'
+        |                    '3': '#/components/schemas/WrongUser'
         |        '404':
         |          description: ''
         |          content:
@@ -170,9 +171,10 @@ class AnyOfSuite extends Http4sHttpRoutesSuite {
         |        name:
         |          type: string
         |        error:
-        |          type: string
+        |          type: integer
+        |          format: int32
         |          enum:
-        |          - user-not-found
+        |          - 1
         |    WrongPassword:
         |      required:
         |      - id
@@ -182,9 +184,10 @@ class AnyOfSuite extends Http4sHttpRoutesSuite {
         |        id:
         |          type: string
         |        error:
-        |          type: string
+        |          type: integer
+        |          format: int32
         |          enum:
-        |          - wrong-password
+        |          - 2
         |    WrongUser:
         |      required:
         |      - id
@@ -194,9 +197,10 @@ class AnyOfSuite extends Http4sHttpRoutesSuite {
         |        id:
         |          type: string
         |        error:
-        |          type: string
+        |          type: integer
+        |          format: int32
         |          enum:
-        |          - wrong-user""".stripMargin
+        |          - 3""".stripMargin
 
     assertNoDiff(toYaml(myEndpoint), expected)
   }

--- a/modules/tapir-anyof/src/test/scala/com/alejandrohdezma/tapir/MyError.scala
+++ b/modules/tapir-anyof/src/test/scala/com/alejandrohdezma/tapir/MyError.scala
@@ -39,14 +39,20 @@ final case class WrongPassword(id: String) extends MyError
 @derive(schema)
 final case class WrongUser(id: String) extends MyError
 
-object anyOf extends AnyOf[MyError](jsonBody)
+object anyOfThese extends AnyOf[MyError](jsonBody)
 
 object MyError {
 
   implicit val configuration: Configuration =
     Configuration.default.withDiscriminator("error").withKebabCaseConstructorNames
 
+  val mapping: String => Int = {
+    case "UserNotFound"  => 1
+    case "WrongPassword" => 2
+    case "WrongUser"     => 3
+  }
+
   implicit lazy val MyErrorSchema: Schema[MyError] =
-    Schema.derived[MyError].addDiscriminator("error", configuration.transformConstructorNames)
+    Schema.derived[MyError].addDiscriminatorAs[Int]("error", mapping)
 
 }


### PR DESCRIPTION
This PR adds a new `addDiscriminatorAs` that can be used to add a discriminator with a type other than `String`:

```scala
@ConfiguredJsonCodec sealed trait MyError extends Throwable

@code(NotFound)
@derive(schema)
@description("Unable to find user")
final case class UserNotFound(name: String) extends MyError

@code(Forbidden)
@derive(schema)
@description("Password is invalid")
final case class WrongPassword(id: String) extends MyError

@code(Forbidden)
@derive(schema)
@description("Username is invalid")
final case class WrongUser(id: String) extends MyError

object anyOfThese extends AnyOf[MyError](jsonBody)

object MyError {

  implicit val configuration: Configuration =
    Configuration.default.withDiscriminator("error").withKebabCaseConstructorNames

  val mapping: String => Int = {
    case "UserNotFound"  => 1
    case "WrongPassword" => 2
    case "WrongUser"     => 3
  }

  implicit lazy val MyErrorSchema: Schema[MyError] =
    Schema.derived[MyError].addDiscriminatorAs[Int]("error", mapping)

}
```